### PR TITLE
Feature/challenge proposal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import Challenge from "components/Challenge/Challenge";
 import Piece from "components/Piece/Piece";
 import ResponsiveLayout from "layouts/responsive.layout";
 import EndedChallenge from "components/Challenge/EndedChallenge";
-import ProposalChallenge from "components/Challenge/ProposalChallenge";
+import ChallengeOffer from "components/Challenge/ChallengeOffer";
 
 const App = () => {
   return (
@@ -24,7 +24,7 @@ const App = () => {
             <Route path="piece" element={<Piece />} />
             <Route path="/sign" element={<Sign />} />
             <Route path="challenge" element={<Challenge />} />
-            <Route path="proposal_challenge" element={<ProposalChallenge />} />
+            <Route path="proposal_challenge" element={<ChallengeOffer />} />
             <Route path="ended_challenge" element={<EndedChallenge />} />
           </Routes>
         </ResponsiveLayout>

--- a/src/components/Card/ChallengeCard.tsx
+++ b/src/components/Card/ChallengeCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import COLOR from "constants/color";
 
 const Container = styled.div`
@@ -9,36 +8,14 @@ const Container = styled.div`
   border-radius: 2rem;
   background-color: ${COLOR.bg.secondary};
   position: relative;
+  margin-left: 5rem; // 잘 보이게 하려고 잠시 설정
 `;
 
-const CompleteThumb = styled.img`
+const Thumbnail = styled.img`
   width: 16.3rem;
   height: 12rem;
   border-radius: 2rem 2rem 0 0;
   margin-bottom: 1rem;
-  filter: brightness(50%);
-`;
-
-const CompleteBox = styled.div`
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  color: ${COLOR.font.primary};
-  width: 3.75rem;
-  height: 3.75rem;
-  border-radius: 50%;
-  background: ${COLOR.black};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const CompleteWord = styled.span`
-  width: 2rem;
-  font-size: 0.875rem;
-  font-family: "Pr-SemiBold";
-  text-align: center;
-  line-height: 1rem;
 `;
 
 const ContenttBox = styled.div`
@@ -91,14 +68,11 @@ const HashTag = styled.div`
   margin-right: 0.5rem;
 `;
 
-const EndedCard = () => {
+const ChallengeCard = () => {
   const Tags = ["001a", "텀블러_챌린지"];
   return (
     <Container>
-      <CompleteThumb src="images/card.png" />
-      <CompleteBox>
-        <CompleteWord>내가 해냄</CompleteWord>
-      </CompleteBox>
+      <Thumbnail src="images/card.png" />
       <ContenttBox>
         <Title>텀블러로 커피 마시는 멋진 나</Title>
         <ChallengeInfo>
@@ -118,4 +92,4 @@ const EndedCard = () => {
   );
 };
 
-export default EndedCard;
+export default ChallengeCard;

--- a/src/components/Card/ChallengeOfferCard.tsx
+++ b/src/components/Card/ChallengeOfferCard.tsx
@@ -1,0 +1,69 @@
+import COLOR from "constants/color";
+import React from "react";
+import styled from "styled-components";
+
+import { AiFillLike, AiOutlineLike } from "react-icons/ai";
+
+interface Props {
+  userName: string;
+  content: string;
+  like: number;
+  clicked: boolean;
+}
+
+const Container = styled.div`
+  width: 22rem;
+  height: auto;
+  border-radius: 1rem;
+  background-color: ${COLOR.bg.secondary};
+  padding: 1rem 1.5rem 2rem 1.5rem;
+  margin-bottom: 3rem;
+`;
+
+const User = styled.div`
+  font-size: 1rem;
+  font-family: "Pr-SemiBold";
+  color: ${COLOR.font.secondary};
+  margin-bottom: 0.5rem;
+`;
+
+const Content = styled.div`
+  font-size: 1rem;
+  font-family: "Pr-SemiBold";
+  color: ${COLOR.white};
+  margin-bottom: 1rem;
+`;
+
+const LikeContainer = styled.div`
+  float: right;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LikeNumber = styled.span`
+  font-size: 1rem;
+  font-family: "Pr-Regular";
+  color: ${COLOR.white};
+  margin-left: 0.5rem;
+`;
+
+const ChallengeOfferCard = (props: Props) => {
+  const { userName, content, like, clicked } = props;
+  return (
+    <Container>
+      <User>{userName}</User>
+      <Content>{content}</Content>
+      <LikeContainer>
+        {clicked ? (
+          <AiFillLike color={COLOR.font.primary} size="20" />
+        ) : (
+          <AiOutlineLike color={COLOR.font.primary} size="20" />
+        )}
+        <LikeNumber>{like}</LikeNumber>
+      </LikeContainer>
+    </Container>
+  );
+};
+
+export default ChallengeOfferCard;

--- a/src/components/Card/EndedChallengeCard.tsx
+++ b/src/components/Card/EndedChallengeCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import styled from "styled-components";
+
+import styled, { css } from "styled-components";
 import COLOR from "constants/color";
 
 const Container = styled.div`
@@ -8,14 +9,36 @@ const Container = styled.div`
   border-radius: 2rem;
   background-color: ${COLOR.bg.secondary};
   position: relative;
-  margin-left: 5rem; // 잘 보이게 하려고 잠시 설정
 `;
 
-const Thumbnail = styled.img`
+const CompleteThumb = styled.img`
   width: 16.3rem;
   height: 12rem;
   border-radius: 2rem 2rem 0 0;
   margin-bottom: 1rem;
+  filter: brightness(50%);
+`;
+
+const CompleteBox = styled.div`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  color: ${COLOR.font.primary};
+  width: 3.75rem;
+  height: 3.75rem;
+  border-radius: 50%;
+  background: ${COLOR.black};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const CompleteWord = styled.span`
+  width: 2rem;
+  font-size: 0.875rem;
+  font-family: "Pr-SemiBold";
+  text-align: center;
+  line-height: 1rem;
 `;
 
 const ContenttBox = styled.div`
@@ -68,11 +91,14 @@ const HashTag = styled.div`
   margin-right: 0.5rem;
 `;
 
-const Card = () => {
+const EndedChallengeCard = () => {
   const Tags = ["001a", "텀블러_챌린지"];
   return (
     <Container>
-      <Thumbnail src="images/card.png" />
+      <CompleteThumb src="images/card.png" />
+      <CompleteBox>
+        <CompleteWord>내가 해냄</CompleteWord>
+      </CompleteBox>
       <ContenttBox>
         <Title>텀블러로 커피 마시는 멋진 나</Title>
         <ChallengeInfo>
@@ -92,4 +118,4 @@ const Card = () => {
   );
 };
 
-export default Card;
+export default EndedChallengeCard;

--- a/src/components/Challenge/Challenge.tsx
+++ b/src/components/Challenge/Challenge.tsx
@@ -1,13 +1,7 @@
-import Card from "components/Card/Card";
 import React from "react";
 
 const Challenge = () => {
-  return (
-    <>
-      <div>진행 중인 챌린지</div>
-      <Card />
-    </>
-  );
+  return <div>진행 중인 챌린지</div>;
 };
 
 export default Challenge;

--- a/src/components/Challenge/ChallengeOffer.tsx
+++ b/src/components/Challenge/ChallengeOffer.tsx
@@ -1,4 +1,3 @@
-import ChallengeOfferCard from "components/Card/ChallengeOfferCard";
 import React from "react";
 
 const ChallengeOffer = () => {

--- a/src/components/Challenge/ChallengeOffer.tsx
+++ b/src/components/Challenge/ChallengeOffer.tsx
@@ -1,0 +1,8 @@
+import ChallengeOfferCard from "components/Card/ChallengeOfferCard";
+import React from "react";
+
+const ChallengeOffer = () => {
+  return <div>챌린지 제안</div>;
+};
+
+export default ChallengeOffer;

--- a/src/components/Challenge/ProposalChallenge.tsx
+++ b/src/components/Challenge/ProposalChallenge.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const ProposalChallenge = () => {
-  return <div>챌린지 제안</div>;
-};
-
-export default ProposalChallenge;


### PR DESCRIPTION
## 작업 내용
- 챌린지 제안 카드 컴포넌트 제작했습니다.
- 사용자 이름, 내용, 좋아요 수, 좋아요 클릭 여부를 props로 받습니다.
- 그리고 기존에 proposal을 붙여서 이름을 지었던 파일을 offer로 수정했습니다 (너무 길어지는거 같아서...)
- 그리고 Card 구분을 위해서 기존에 있던 Card, EndedCard 컴포넌트에 Challenge 접두어를 붙였습니담 (ChallengeCard, EndedChallengeCard)
- 그리고 지금은 내용에 따라 높이를 자동조정 하도록 했는데, 만약 내용이 엄청 길어진다면 어떻게 할지..회의를 해봐야 할 것 같아요

<img width="310" alt="스크린샷 2022-08-17 오후 7 38 05" src="https://user-images.githubusercontent.com/66055587/185100726-1889bf83-651b-4bf7-809b-100290f437ca.png">

## 추가 사항
- 그리고 추가적으로 #26 이거 props도 안 받고 진행 중인 챌린지 페이지에서만 쓰이는 것 같은데,  따로 컴포넌트로 안빼고 그냥 진행중인 챌린지 페이지 작업할 때 해버리는거로 해도 되지 않을까 해서 물어봅니당
