### PR TITLE
Feature/36 challenge title

### DIFF
--- a/src/components/Card/EndedCard.tsx
+++ b/src/components/Card/EndedCard.tsx
@@ -9,6 +9,7 @@ const Container = styled.div`
   border-radius: 2rem;
   background-color: ${COLOR.bg.secondary};
   position: relative;
+  margin-bottom: 2.8rem;
 `;
 
 const CompleteThumb = styled.img`

--- a/src/components/Challenge/Challenge.tsx
+++ b/src/components/Challenge/Challenge.tsx
@@ -1,15 +1,14 @@
-import Card from "components/Card/Card";
-import EndedCard from "components/Card/EndedCard";
+import ChallengeTitle from "components/common/ChallengeTitle";
 import React from "react";
 
-import styled, { css } from "styled-components";
-
-const Title = styled.div`
-  margin-bottom: 1.5rem;
-`;
-
 const Challenge = () => {
-  return <Title>진행 중인 챌린지</Title>;
+  return (
+    <ChallengeTitle
+      title="📌 오늘의 챌린지"
+      toolTip
+      toolTipContent="오늘만 참여할 수 있는 챌린지에요. 한번 바로 확인해볼까요"
+    />
+  );
 };
 
 export default Challenge;

--- a/src/components/Challenge/Challenge.tsx
+++ b/src/components/Challenge/Challenge.tsx
@@ -5,7 +5,6 @@ const Challenge = () => {
   return (
     <ChallengeTitle
       title="📌 오늘의 챌린지"
-      toolTip
       toolTipContent="오늘만 참여할 수 있는 챌린지에요. 한번 바로 확인해볼까요"
     />
   );

--- a/src/components/Challenge/EndedChallenge.tsx
+++ b/src/components/Challenge/EndedChallenge.tsx
@@ -21,7 +21,7 @@ const CardContainer = styled.div`
 const EndedChallenge = () => {
   return (
     <Container>
-      <ChallengeTitle title="📌 지난 챌린지" toolTip={false} />
+      <ChallengeTitle title="📌 지난 챌린지" />
       <CardContainer>
         <EndedCard />
         <Card />

--- a/src/components/Challenge/EndedChallenge.tsx
+++ b/src/components/Challenge/EndedChallenge.tsx
@@ -1,5 +1,6 @@
 import Card from "components/Card/Card";
 import EndedCard from "components/Card/EndedCard";
+import ChallengeTitle from "components/common/ChallengeTitle";
 import React from "react";
 
 import styled from "styled-components";
@@ -7,10 +8,6 @@ import styled from "styled-components";
 const Container = styled.div`
   width: 73.56rem;
   margin: 1rem auto;
-`;
-
-const Title = styled.div`
-  margin-bottom: 1.5rem;
 `;
 
 const CardContainer = styled.div`
@@ -24,7 +21,7 @@ const CardContainer = styled.div`
 const EndedChallenge = () => {
   return (
     <Container>
-      <Title>지난 챌린지</Title>
+      <ChallengeTitle title="📌 지난 챌린지" toolTip={false} />
       <CardContainer>
         <EndedCard />
         <Card />

--- a/src/components/common/ChallengeTitle.tsx
+++ b/src/components/common/ChallengeTitle.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 
 interface Props {
   title: string;
-  toolTip: boolean;
   toolTipContent?: string;
 }
 
@@ -23,12 +22,12 @@ const Title = styled.div`
 `;
 
 const ChallengeTitle = (props: Props) => {
-  const { title, toolTip, toolTipContent } = props;
+  const { title, toolTipContent } = props;
 
   return (
     <Container>
       <Title>{title}</Title>
-      {toolTip && (
+      {toolTipContent && (
         <HoverTooltip top="-8.5rem" left="9rem">
           {toolTipContent}
         </HoverTooltip>

--- a/src/components/common/ChallengeTitle.tsx
+++ b/src/components/common/ChallengeTitle.tsx
@@ -1,0 +1,41 @@
+import HoverTooltip from "components/Tooltip/Tooltip";
+import React from "react";
+import styled from "styled-components";
+
+interface Props {
+  title: string;
+  toolTip: boolean;
+  toolTipContent?: string;
+}
+
+const defaultProps = {
+  toolTipContent: "",
+};
+
+const Container = styled.div`
+  display: flex;
+  margin: 1.5rem 0;
+`;
+
+const Title = styled.div`
+  font-size: 1.56rem;
+  font-family: "Pr-Bold";
+`;
+
+const ChallengeTitle = (props: Props) => {
+  const { title, toolTip, toolTipContent } = props;
+
+  return (
+    <Container>
+      <Title>{title}</Title>
+      {toolTip && (
+        <HoverTooltip top="-8.5rem" left="9rem">
+          {toolTipContent}
+        </HoverTooltip>
+      )}
+    </Container>
+  );
+};
+ChallengeTitle.defaultProps = defaultProps;
+
+export default ChallengeTitle;


### PR DESCRIPTION
## 작업 내용
- 챌린지 타이틀 컴포넌트 완성했습니다.
- 지난 챌린지 레이아웃은 완성됐습니다 (추후에 무한 스크롤 구현)
- 그리고 지금 main branch에서는 지난 챌린지 카드 레이아웃이 살짝 위 아래로 살짝 망가진 부분이 있는데 (margin 잘못 줘서), 이 pr에서 해결됩니다.

<img width="290" alt="스크린샷 2022-08-18 오후 12 28 51" src="https://user-images.githubusercontent.com/66055587/185287477-05753c39-ba7b-43f5-944a-f111b3432a47.png">
<img width="1779" alt="스크린샷 2022-08-18 오후 12 29 47" src="https://user-images.githubusercontent.com/66055587/185287492-fd65d39e-1ba4-444b-9ca1-84abed89ec88.png">

## 사용 방법
- props로 title, toolTip, toolTipContent를 넘겨줍니다. toolTip은 boolean 값이며 만약 toolTip을 사용한다면 toolTipContent에 채울 내용을 넘겨주면 됩니다.

![스크린샷 2022-08-18 오후 12 36 27](https://user-images.githubusercontent.com/66055587/185287673-750f781c-77a2-435b-8c64-0f0c64c58eee.png)

## 추가 사항
- toolTip 위치가 현재 문제가 있어서 @soyekwon 의 추가 작업이 완료되면 toolTip 위치는 바로 수정할게욤
