### PR TITLE
Feat: 내가 해냄 아이콘 분리

### DIFF
--- a/src/components/Card/EndedCard.tsx
+++ b/src/components/Card/EndedCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import styled from "styled-components";
 import COLOR from "constants/color";
+import DidItIcon from "components/common/DidItIcon";
 
 const Container = styled.div`
   width: 16.3rem;
@@ -19,29 +20,7 @@ const CompleteThumb = styled.img`
   filter: brightness(50%);
 `;
 
-const CompleteBox = styled.div`
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  color: ${COLOR.font.primary};
-  width: 3.75rem;
-  height: 3.75rem;
-  border-radius: 50%;
-  background: ${COLOR.black};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const CompleteWord = styled.span`
-  width: 2rem;
-  font-size: 0.875rem;
-  font-family: "Pr-SemiBold";
-  text-align: center;
-  line-height: 1rem;
-`;
-
-const ContenttBox = styled.div`
+const ContentBox = styled.div`
   margin-left: 1rem;
 `;
 
@@ -96,10 +75,8 @@ const EndedCard = () => {
   return (
     <Container>
       <CompleteThumb src="images/card.png" />
-      <CompleteBox>
-        <CompleteWord>내가 해냄</CompleteWord>
-      </CompleteBox>
-      <ContenttBox>
+      <DidItIcon isAbsolute top="1rem" right="1rem" />
+      <ContentBox>
         <Title>텀블러로 커피 마시는 멋진 나</Title>
         <ChallengeInfo>
           <Personnel>
@@ -113,7 +90,7 @@ const EndedCard = () => {
             <HashTag key={index}>#{tag}</HashTag>
           ))}
         </HashTagBox>
-      </ContenttBox>
+      </ContentBox>
     </Container>
   );
 };

--- a/src/components/common/DidItIcon.tsx
+++ b/src/components/common/DidItIcon.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import styled from "styled-components";
+import COLOR from "constants/color";
+
+interface Props {
+  isAbsolute: boolean;
+  top?: string;
+  right?: string;
+}
+
+const defaultProps = {
+  top: "0",
+  right: "0",
+};
+
+const CompleteBox = styled.div`
+  position: ${(props: Props) => props.isAbsolute && "absolute"};
+  top: ${(props: Props) => props.top};
+  right: ${(props: Props) => props.right};
+  color: ${COLOR.font.primary};
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 50%;
+  background: ${COLOR.black};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const CompleteWord = styled.span`
+  width: 2rem;
+  font-size: 0.875rem;
+  font-family: "Pr-SemiBold";
+  text-align: center;
+  line-height: 1rem;
+`;
+
+const DidItIcon = (props: Props) => {
+  const { isAbsolute, top, right } = props;
+  return (
+    <CompleteBox isAbsolute={isAbsolute} top={top} right={right}>
+      <CompleteWord>내가 해냄</CompleteWord>
+    </CompleteBox>
+  );
+};
+DidItIcon.defaultProps = defaultProps;
+
+export default DidItIcon;

--- a/src/components/common/DidItIcon.tsx
+++ b/src/components/common/DidItIcon.tsx
@@ -4,12 +4,13 @@ import styled from "styled-components";
 import COLOR from "constants/color";
 
 interface Props {
-  isAbsolute: boolean;
+  isAbsolute?: boolean;
   top?: string;
   right?: string;
 }
 
 const defaultProps = {
+  isAbsolute: false,
   top: "0",
   right: "0",
 };


### PR DESCRIPTION
## 작업 내용
- 내가 해냄 아이콘 컴포넌트 분리 했습니다.
- 이게 카드에 붙어있는거랑 그 피스상세에서 크기가 아주 살짝 달라서 props으로 너비를 조정하기 보다는 이 2가지 디자인의 중간값 정도로 width,height를 고정했어요. 둘 다 자연스러워서 이렇게 가도 될 것 같은데, 혹시 조정할 수 있도록 해야할 것 같으면 수정하겠습니당
- 그리고 이게 카드에 붙어 있는 것처럼 position 속성을 사용해야할 때도 있고, 그냥 div처럼 사용해야할 떄도 있는 것 같아서 isAbsolute라는 prop으로 조정하도록 했습니다.

<img width="221" alt="스크린샷 2022-08-18 오후 1 06 17" src="https://user-images.githubusercontent.com/66055587/185291419-95a79614-9687-4f96-b795-38feb3767949.png">
<img width="123" alt="스크린샷 2022-08-18 오후 1 06 12" src="https://user-images.githubusercontent.com/66055587/185291424-1e4d53ac-7fc2-402b-8be0-84b1b1bc1bff.png">

## 사용 방법
- Div 처럼 사용하려면 아래 사진과 같이 isAbsoulte를 false로 넘겨주고 사용하면 됩니다.
![스크린샷 2022-08-18 오후 1 08 12](https://user-images.githubusercontent.com/66055587/185291596-3145cac8-0ddf-45f9-9359-3acbc968ef27.png)

- 카드 컴포넌트처럼 어느 위치에 의존해야하면, 아래 사진과 같이 isAbsoulte를 true로 넘겨주고 top과 right로 위치를 조정하면 됩니다. 그리고 상위 컴포넌트에 position: relative; 속성을 줘야합니다.
![스크린샷 2022-08-18 오후 1 09 10](https://user-images.githubusercontent.com/66055587/185291701-ad62549b-5c71-4507-ac86-6ec966d3f779.png)

