### PR TITLE
Feature/90 close warning modal

### DIFF
--- a/src/components/Modal/CloseWarningModal.tsx
+++ b/src/components/Modal/CloseWarningModal.tsx
@@ -1,0 +1,25 @@
+import { FlexTextBox } from "components/common";
+import COLOR from "constants/color";
+import ModalFrame from "./ModalFrame";
+
+const CloseWarningModal = () => (
+  <ModalFrame
+    modalMainColor={COLOR.font.danger}
+    width="52.25rem"
+    height="23.56rem"
+    title="작성하던 내용이 사라질 수 있어요!"
+    btnTitle1="다시 작성하러 가기"
+    btnTitle2="괜찮아요"
+  >
+    <FlexTextBox
+      fontSize="1.25rem"
+      fontFamily="Pr-Bold"
+      color={COLOR.white}
+      margin="2rem 0 0 0"
+    >
+      작성중인 내용은 저장되지 않아요. 정말 작성을 그만두시나요? 🥺
+    </FlexTextBox>
+  </ModalFrame>
+);
+
+export default CloseWarningModal;

--- a/src/components/Modal/ModalFrame.tsx
+++ b/src/components/Modal/ModalFrame.tsx
@@ -1,77 +1,94 @@
-import { useState } from "react";
 import styled from "styled-components";
 import COLOR from "constants/color";
 import { AiOutlineClose } from "react-icons/ai";
+import { FlexTextBox } from "components/common";
 import FlexBox from "../common/FlexBox";
 import FlexButton from "../common/FlexButton";
 
 interface Props {
   children: React.ReactNode;
-  titleColor?: string;
+  modalMainColor?: string;
+  width: string;
+  height: string;
+  title: string;
+  btnTitle1: string;
+  btnTitle2: string;
+  subTitle?: string;
+  background?: string;
 }
 
 const defaultProps = {
-  titleColor: "white",
-};
-
-const ModalBlock = styled.div`
-  width: 45%;
-  height: auto;
-  border-radius: 0.8rem;
-  display: flex;
-  margin-left: 25%;
-  padding: 1rem;
-  background-color: ${COLOR.bg.default};
-  display: flex;
-  flex-direction: column;
-  animation: modal-show 1s;
-`;
-
-const Title = styled.div<Props>`
-  width: 100%;
-  height: 4rem;
-  margin-right: 0;
-  color: ${(props) => props.color};
-  font-size: 30px;
-  font-weight: bold;
-`;
-
-// 임시 모달 데이터
-const data = {
-  title: "일회용품 No! 다시 쓰기 Yes! 챌린지 인증하기",
-  content: "이것은 내용입니다. 블라블라 ~ 여기에 본문 내용을 ...... ",
+  modalMainColor: COLOR.font.primary,
+  subTitle: "",
+  background: COLOR.bg.default,
 };
 
 const ModalFrame = (props: Props) => {
-  const { children, titleColor } = props;
-  const [modalData] = useState(data);
+  const {
+    children,
+    modalMainColor,
+    width,
+    height,
+    title,
+    btnTitle1,
+    btnTitle2,
+    subTitle,
+    background,
+  } = props;
+
   return (
-    <ModalBlock>
-      <FlexBox padding="1%">
-        <Title color={titleColor}>{modalData.title}</Title>
+    <FlexBox
+      background={background}
+      width={width}
+      height={height}
+      column
+      padding="3rem"
+      borderRadius="1.25rem"
+      position="relative"
+    >
+      <FlexBox
+        width="100%"
+        justifyContent="space-between"
+        alignItems="center"
+        margin="0 0 2rem 0"
+      >
+        <FlexBox>
+          <FlexTextBox
+            color={modalMainColor}
+            fontSize="1.875rem"
+            fontFamily="Pr-Bold"
+          >
+            {title}
+          </FlexTextBox>
+          {subTitle && (
+            <FlexTextBox
+              color={COLOR.white}
+              fontSize="1.875rem"
+              fontFamily="Pr-Bold"
+              margin="0 0 0 1rem"
+            >
+              {subTitle}
+            </FlexTextBox>
+          )}
+        </FlexBox>
+
         <AiOutlineClose color={COLOR.white} size="28" />
       </FlexBox>
-
-      <FlexBox padding="0 2% 0 2%">{children}</FlexBox>
-
-      <FlexBox margin="15% 0 0 60%">
-        <FlexButton
-          margin="0 0 0 0.4rem"
-          fontSize="1.5rem"
-          backgroundColor={COLOR.bg.default}
-        >
-          취소
+      <FlexBox>{children}</FlexBox>
+      <FlexBox position="absolute" right="3rem" bottom="2rem">
+        <FlexButton fontSize="1.56rem" backgroundColor={COLOR.bg.default}>
+          {btnTitle1}
         </FlexButton>
         <FlexButton
-          margin="0 0 0 0.8rem"
-          color={COLOR.font.primary}
-          fontSize="1.5rem"
+          margin="0 0 0 1rem"
+          color={modalMainColor}
+          fontSize="1.56rem"
           backgroundColor={COLOR.bg.primary}
         >
-          확인
+          {btnTitle2}
         </FlexButton>
       </FlexBox>
-    </ModalBlock>
+    </FlexBox>
   );
 };
 ModalFrame.defaultProps = defaultProps;

--- a/src/components/common/FlexBox.tsx
+++ b/src/components/common/FlexBox.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import COLOR from "constants/color";
 
 interface Props {
   children: React.ReactNode;
@@ -17,6 +16,8 @@ interface Props {
   center?: boolean;
   background?: string;
   position?: string;
+  right?: string;
+  bottom?: string;
 }
 
 const defaultProps = {
@@ -34,6 +35,8 @@ const defaultProps = {
   center: false,
   position: "static",
   background: "transparent",
+  right: "0",
+  bottom: "0",
 };
 
 const FlexBox = (props: Props) => {
@@ -53,6 +56,8 @@ const FlexBox = (props: Props) => {
     center,
     background,
     position,
+    right,
+    bottom,
   } = props;
 
   const dir = (column ? "column" : "row") + (reverse ? "-reverse" : "");
@@ -70,6 +75,8 @@ const FlexBox = (props: Props) => {
     align-items: ${center ? "center" : alignItems};
     background: ${background};
     position: ${position};
+    right: ${right};
+    bottom: ${bottom};
   `;
 
   return <Flexbox dir={dir}>{children}</Flexbox>;


### PR DESCRIPTION
## 작업 내용
- 닫기 경고 모달 컴포넌트 제작 했습니다.
- 기존 기획이랑 배경색이 다른데, 결과 화면 캡처를 위해 background와 구별하기 위해서 임시로 색깔을 바꿨습니다. 코드에는 원래 기획의 색으로 넣어놨습니다.
<img width="837" alt="스크린샷 2022-09-02 오후 9 32 35" src="https://user-images.githubusercontent.com/66055587/188143823-c866ebef-0bc4-466b-affe-7aa910e34708.png">

## ModalFrame Component
- 기존에 기획한 Modal 컴포넌트와 현재 기획되고 있는 Modal의 구성이 조금 달라 ModalFrame 컴포넌트를 재구성 했습니다.
### 인자들은 다음과 같습니다. 설명이 필요한 인자들만 설명 적겠습니다.
![스크린샷 2022-09-02 오후 9 36 55](https://user-images.githubusercontent.com/66055587/188145078-3dd07a76-0db6-4ef9-a0c0-6f5d619432b4.png)
- children: 모달 가운데에 들어갈 요소들을 children으로 전달합니다.
- title: 모달의 제목을 전달합니다
- subTitle: 아래의 모달과 같이 subTitle이 있는 경우 subTitle을 전달할 수 있습니다
<img width="796" alt="스크린샷 2022-09-02 오후 9 37 32" src="https://user-images.githubusercontent.com/66055587/188145424-501ebcca-e73b-407b-8961-67226e3bbb89.png">
- modalMainColor: 다음 사진과 같이 해당 모달의 mainColor를 설정합니다.
<img width="837" alt="스크린샷 2022-09-02 오후 9 32 35" src="https://user-images.githubusercontent.com/66055587/188145863-30a1c8f1-2c4c-4358-9b23-c0be0063b3cf.png">
- btnTitle1, btnTitle2 : 모달의 2가지 버튼의 제목을 지정합니다

