### PR TITLE
Feature/91 챌린지 상세페이지 레이아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   EndedChallenge,
   ChallengeOffer,
   Piece,
+  ChallengeDetail,
 } from "pages";
 
 import ResponsiveLayout from "layouts/responsive.layout";
@@ -41,7 +42,7 @@ const App = () => {
               <Route path="/" element={<Island />} />
               <Route path="/sign" element={<Sign />} />
               <Route path="/challenge" element={<Challenge />} />
-              <Route path="/challenge/:id" element={<div />} />
+              <Route path="/challenge/:id" element={<ChallengeDetail />} />
               <Route path="/challenge/ended" element={<EndedChallenge />} />
               <Route path="/challenge/offer" element={<ChallengeOffer />} />
               <Route path="/piece" element={<Piece />} />

--- a/src/components/Challenge/Banner/CertificationBanner.tsx
+++ b/src/components/Challenge/Banner/CertificationBanner.tsx
@@ -11,10 +11,15 @@ const script = {
 const dummyChallenge = {
   userName: "김신건",
   challengeTitle: "일회용품 No! 다시 쓰기 Yes!",
+  isCertified: true,
 };
 
 const PrimaryText = styled.span`
   color: ${COLOR.font.primary};
+`;
+
+const CertifiedText = styled.span`
+  color: ${COLOR.font.info};
 `;
 
 const CertificationBanner = () => {
@@ -34,19 +39,29 @@ const CertificationBanner = () => {
           <FlexTextBox fontFamily="Pr-Bold">
             <PrimaryText>{dummyChallenge.userName}</PrimaryText>님, <br />
             <PrimaryText>{dummyChallenge.challengeTitle}</PrimaryText> <br />
-            챌린지 미션을 달성하셨나요?
+            {dummyChallenge.isCertified ? (
+              <FlexTextBox>
+                챌린지 미션은 이미 <CertifiedText>인증</CertifiedText>하셨네요!
+              </FlexTextBox>
+            ) : (
+              <FlexTextBox>챌린지 미션을 달성하셨나요?</FlexTextBox>
+            )}
           </FlexTextBox>
           <FlexButton
             borderRadius="0.625rem"
             backgroundColor={COLOR.bg.primary}
-            color={COLOR.font.primary}
+            color={
+              dummyChallenge.isCertified
+                ? COLOR.font.primaryDisabled
+                : COLOR.font.primary
+            }
             fontSize="1.25rem"
             fontFamily="Pr-Bold"
             position="absolute"
             right="1rem"
             bottom="1rem"
           >
-            인증하기
+            {dummyChallenge.isCertified ? "인증완료" : "인증하기"}
           </FlexButton>
         </BannerBox>
       </FlexBox>

--- a/src/components/Challenge/Banner/ChallengeDetailBanner.tsx
+++ b/src/components/Challenge/Banner/ChallengeDetailBanner.tsx
@@ -5,15 +5,18 @@ import { Paper } from "@mui/material";
 import Carousel from "react-material-ui-carousel";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import { DidItIcon } from "..";
 
 const dummyData = {
   title: "일회용품 No! 다시 쓰기 Yes",
   description:
     "여기는 챌린지 description이 들어가는 자리입니다. 이 챌린지는 블라블라 ~~~~ 이 챌린지는 블라블라 ~~~~ 이 챌린지는 블라블라 ~~~~ 이 챌린지 블라블라 ~~~~이 챌린지는 블라블라 ~~~~이 챌린지는 블라블라 ~~~~이 챌린지는 블라블라 ~~~~이 챌린지는 블라블라 ~~~~",
   categories: ["일회용품_줄이기", "재활용_캠페인"],
-  images: ["images/image1.png", "images/image2.png", "images/image3.png"],
+  images: ["/images/image1.png", "/images/image2.png", "/images/image3.png"],
   prover_cnt: 34,
   point: 100,
+  userDone: true,
+  ended: true,
 };
 
 const Thumbnail = styled.img`
@@ -78,14 +81,23 @@ const ChallengeDetailBanner = () => {
   const insertBtn = loopBtn();
   return (
     <BannerBox width="52.25rem" padding="1rem">
-      <Thumbnail src="images/thumbnail.png" />
-      <FlexTextBox
-        fontSize="1.8rem"
-        fontFamily="Pr-Bold"
-        margin="1.5rem 0 0.5rem 1.3rem"
-      >
-        {dummyData.title}
-      </FlexTextBox>
+      <Thumbnail src="/images/thumbnail.png" />
+      <FlexBox alignItems="center" margin="1.5rem 0 0.5rem 1.3rem">
+        {dummyData.ended && (
+          <FlexTextBox
+            fontSize="1.56rem"
+            fontFamily="Pr-SemiBold"
+            color={COLOR.font.info}
+            margin="0 0.5rem 0 0"
+          >
+            [종료]
+          </FlexTextBox>
+        )}
+        <FlexTextBox fontSize="1.8rem" fontFamily="Pr-Bold" margin="0 1rem 0 0">
+          {dummyData.title}
+        </FlexTextBox>
+        {dummyData.userDone && <DidItIcon />}
+      </FlexBox>
       <FlexBox background="transparent" margin="1rem 0 1rem 0">
         {insertBtn}
       </FlexBox>

--- a/src/components/Challenge/Banner/ChallengeTestimonial.tsx
+++ b/src/components/Challenge/Banner/ChallengeTestimonial.tsx
@@ -19,30 +19,30 @@ export type PieceType = {
 const dummyPieces = [
   {
     id: "1",
-    avatar: "images/man.png",
+    avatar: "/images/man.png",
     userName: "홍길동",
     date: "2022.08.10",
     content:
       "이번 챌린지는 정말 어려웠습니다. 각급 선거관리위원회는 선거인명부의 작성등 선거사무와 국민투표사무에 관하여 관계 행정기관에 필요한 지시를 할 수 있다. 헌법재판소는 법관의 자격을 가진 9인의 재판관으로 구성하며, 재판관은 대통령이 임명한다. 정당은 법률이 정하는 바에 의하여 국가의 보호를 받으며, 국가는 법률이 정하는 바에 의하여 정당운영에 필요한...",
     images: [
-      { id: 1, image_url: "images/image3.png" },
-      { id: 2, image_url: "images/image4.png" },
-      { id: 3, image_url: "images/image5.png" },
-      { id: 4, image_url: "images/image3.png" },
+      { id: 1, image_url: "/images/image3.png" },
+      { id: 2, image_url: "/images/image4.png" },
+      { id: 3, image_url: "/images/image5.png" },
+      { id: 4, image_url: "/images/image3.png" },
     ],
   },
   {
     id: "1",
-    avatar: "images/man.png",
+    avatar: "/images/man.png",
     userName: "홍길동",
     date: "2022.08.10",
     content:
       "이번 챌린지는 정말 어려웠습니다. 각급 선거관리위원회는 선거인명부의 작성등 선거사무와 국민투표사무에 관하여 관계 행정기관에 필요한 지시를 할 수 있다. 헌법재판소는 법관의 자격을 가진 9인의 재판관으로 구성하며, 재판관은 대통령이 임명한다. 정당은 법률이 정하는 바에 의하여 국가의 보호를 받으며, 국가는 법률이 정하는 바에 의하여 정당운영에 필요한...",
     images: [
-      { id: 1, image_url: "images/image3.png" },
-      { id: 2, image_url: "images/image4.png" },
-      { id: 3, image_url: "images/image5.png" },
-      { id: 4, image_url: "images/image3.png" },
+      { id: 1, image_url: "/images/image3.png" },
+      { id: 2, image_url: "/images/image4.png" },
+      { id: 3, image_url: "/images/image5.png" },
+      { id: 4, image_url: "/images/image3.png" },
     ],
   },
 ];
@@ -66,6 +66,7 @@ const ChallengeTestimonial = () => {
         alignItems="center"
         padding="0 0 0 2rem"
         margin="2rem 0 0 0"
+        background={COLOR.bg.default}
       >
         <FlexTextBox
           fontSize="1.25rem"

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -10,6 +10,7 @@ const COLOR = {
     info: "#37f0e5",
     link: "#37f0e5",
     danger: "#ff4d4d",
+    primaryDisabled: "#1E9048",
   },
   btn: {
     default: "#f6f6f6",

--- a/src/pages/ChallengeDetail.tsx
+++ b/src/pages/ChallengeDetail.tsx
@@ -1,0 +1,22 @@
+import CertificationBanner from "components/Challenge/Banner/CertificationBanner";
+import ChallengeDetailBanner from "components/Challenge/Banner/ChallengeDetailBanner";
+import ChallengeTestimonial from "components/Challenge/Banner/ChallengeTestimonial";
+import SimilarChallengeBanner from "components/Challenge/Banner/SimilarChallengeBanner";
+import { FlexBox } from "components/common";
+
+const ChallengeDetail = () => {
+  return (
+    <FlexBox justifyContent="center" height="100%">
+      <FlexBox column alignItems="center" margin="0 0 10rem 0">
+        <ChallengeDetailBanner />
+        <ChallengeTestimonial />
+      </FlexBox>
+      <FlexBox column alignItems="center">
+        <CertificationBanner />
+        <SimilarChallengeBanner />
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default ChallengeDetail;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,4 +4,5 @@ export { default as Island } from "./Island";
 export { default as Challenge } from "./Challenge";
 export { default as ChallengeOffer } from "./ChallengeOffer";
 export { default as EndedChallenge } from "./EndedChallenge";
+export { default as ChallengeDetail } from "./ChallengeDetail";
 export { default as Piece } from "./Piece";


### PR DESCRIPTION
## 작업 내용
- 챌린지 상세페이지 레이아웃 제작 했습니다.
![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/66055587/188260116-a131b877-c5f7-435c-8972-0fddd5b38d75.gif)

## 추후 조정해야 할 내용들
- 챌린지 상세페이지 들어갔을 때 진행중인 챌린지 navbar가 나오게 해야함
- 챌린지 상세페이지에서 challenge 데이터를 하위 컴포넌트에 뿌려주는 형식이 되도록 구조를 변경해야함 -> 지금 하위 컴포넌트들이 다 각각 다른 더미데이터로 구성되어 있어, api 연결하면 해당 데이터 구조로 싹 고치려고 합니다..