### PR TITLE
feat: 알림 키워드 설정 모달

### DIFF
--- a/src/components/Challenge/Card/NoticKeyword.tsx
+++ b/src/components/Challenge/Card/NoticKeyword.tsx
@@ -5,8 +5,28 @@ import BannerBox from "components/common/BannerBox";
 import Tooltip from "components/Tooltip/Tooltip";
 import FlexButton from "components/common/FlexButton";
 import FlexBox from "components/common/FlexBox";
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
+import NoticKeywordModal from "components/Modal/NoticeKeywordModal";
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "40rem",
+  height: "25rem",
+  borderRadius: "1rem",
+  bgcolor: COLOR.bg.default,
+  color: "#efefef",
+  boxShadow: 24,
+  p: 4,
+};
 
 const NoticKeyword = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
   const [keywords] = useState([
     "일회용품_안_쓰기",
     "텀블러",
@@ -42,9 +62,20 @@ const NoticKeyword = () => {
           margin="0 0 0 14rem"
           fontSize="0.9rem"
           fontFamily="Pr-Regular"
+          onClick={handleOpen}
         >
           수정하기{">"}
         </FlexButton>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Box sx={style}>
+            <NoticKeywordModal onClick={handleClose} />
+          </Box>
+        </Modal>
         <FlexBox margin="0.5rem" wrap="wrap">
           {keywords.map((keyword: string) => (
             <FlexTextBox

--- a/src/components/Challenge/Card/NoticKeyword.tsx
+++ b/src/components/Challenge/Card/NoticKeyword.tsx
@@ -15,7 +15,6 @@ const style = {
   left: "50%",
   transform: "translate(-50%, -50%)",
   width: "40rem",
-  height: "25rem",
   borderRadius: "1rem",
   bgcolor: COLOR.bg.default,
   color: "#efefef",

--- a/src/components/Modal/NoticeKeywordModal.tsx
+++ b/src/components/Modal/NoticeKeywordModal.tsx
@@ -5,6 +5,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import FlexBox from "components/common/FlexBox";
 import AutoComplete from "components/Form/AutoComplete";
 import { Icon, Label } from "semantic-ui-react";
+import { FlexTextBox } from "components/common";
 
 interface Props {
   onClick: () => void;
@@ -59,10 +60,11 @@ const NoticKeywordModal = ({ onClick }: Props) => {
         style={{ position: "absolute", right: 0, cursor: "pointer" }}
         onClick={onClick}
       />
+      <FlexTextBox fontSize="1.5rem">알림 키워드</FlexTextBox>
       <FlexBox wrap="wrap" margin="2rem 0 1rem 0">
         {insertTags()}
       </FlexBox>
-      <FlexBox>
+      <FlexBox margin="0 0 0 18rem">
         <AutoComplete />
       </FlexBox>
     </FlexBox>

--- a/src/components/Modal/NoticeKeywordModal.tsx
+++ b/src/components/Modal/NoticeKeywordModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import COLOR from "constants/color";
+import styled from "styled-components";
+import { AiOutlineClose } from "react-icons/ai";
+import FlexBox from "components/common/FlexBox";
+import AutoComplete from "components/Form/AutoComplete";
+import { Icon, Label } from "semantic-ui-react";
+
+interface Props {
+  onClick: () => void;
+}
+
+const Box = styled.div`
+  max-width: 12.5rem;
+  margin-right: 0.2rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const TagLabel = styled(Label)`
+  padding: 1rem !important;
+  margin: 0 0.5rem 0.5rem 0 !important;
+  font-size: 1rem !important;
+  color: white !important;
+  background: ${COLOR.bg.primary} !important;
+`;
+
+const NoticKeywordModal = ({ onClick }: Props) => {
+  const [keywords] = useState([
+    "일회용품_안_쓰기",
+    "텀블러",
+    "이_세상에는_다시_쓸_수_있는_물건이_많다",
+    "친환경_습관_기르기",
+    "일회용품_대신_텀블러",
+    "에코백_활용",
+  ]);
+
+  const insertTags = () => {
+    const newArr = [];
+    for (let i = 0; i < keywords.length; i += 1) {
+      newArr.push(
+        <TagLabel>
+          <FlexBox>
+            <Box>{keywords[i]}</Box>
+            <Icon name="delete" link />
+          </FlexBox>
+        </TagLabel>
+      );
+    }
+    return newArr;
+  };
+
+  return (
+    <FlexBox column position="relative">
+      <AiOutlineClose
+        color={COLOR.white}
+        size="28"
+        style={{ position: "absolute", right: 0, cursor: "pointer" }}
+        onClick={onClick}
+      />
+      <FlexBox wrap="wrap" margin="2rem 0 1rem 0">
+        {insertTags()}
+      </FlexBox>
+      <FlexBox>
+        <AutoComplete />
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default NoticKeywordModal;


### PR DESCRIPTION
![화면 캡처 2022-09-06 194502](https://user-images.githubusercontent.com/55877726/188615880-44328459-0514-4ace-a02f-36ec32f9f0d5.jpg)
수정하기 > 버튼 누르면 모달 뜹니다. 
lex-wrap, 일정 너비 (12.5rem) 넘으면 ... 표시 후 잘립니다. 
모달 띄우고 닫는 부분은 @mui/material/Modal 사용하면 편하길래 사용하긴 했는데 다른 모달 띄우는 부분이랑 통일성 있게 하려면 원래 띄우는 방식으로 해야될 거 같기도 하고 ... 그래야 할 거 같으면 말해줘! 수정하겠습니다  @cychann 
입력 후 처리는 민정이가 모달 구현 되고 한다 해서 남겨놨습니다! @minjj0905 

더 추가로 넣고 싶은 부분 있으면 말해주세요 
그리고 디자인 ... 어떡하죠 ? ... 민정이가 디자인 잘하니까 입력 후 처리할 때 조금 수정해줬으면 좋겠엉 