### PR TITLE
#157 챌린지 제안 페이지 레이아웃 조절

### DIFF
--- a/src/components/Challenge/AllChallengeOfferList.tsx
+++ b/src/components/Challenge/AllChallengeOfferList.tsx
@@ -10,7 +10,12 @@ interface Props {
 const AllChallengeOfferList = (props: Props) => {
   const { suggestions } = props;
   return (
-    <FlexBox wrap="wrap" margin="2rem 0 0 0" background={COLOR.bg.primary}>
+    <FlexBox
+      wrap="wrap"
+      margin="2rem 0 0 0"
+      background={COLOR.bg.primary}
+      gap="1rem"
+    >
       {suggestions.map((suggestion) => {
         return (
           <ChallengeOfferCard
@@ -19,6 +24,7 @@ const AllChallengeOfferList = (props: Props) => {
             content={suggestion.content}
             feedbackCount={suggestion.feedback_count}
             isFeedbacked={suggestion.is_feedbacked}
+            gap="1rem"
           />
         );
       })}

--- a/src/components/Challenge/Banner/AllChallengeOffer.tsx
+++ b/src/components/Challenge/Banner/AllChallengeOffer.tsx
@@ -20,15 +20,7 @@ const AllChallengeOffer = () => {
   }, [inView]);
 
   return (
-    <ChallengeBanner
-      title={script.title}
-      width="76rem"
-      maxWidthTablet="1250px"
-      widthTablet="51rem"
-      maxWidthMobile="768px"
-      widthMobile="26.5rem"
-      padding="2rem"
-    >
+    <ChallengeBanner title={script.title} width="100%" padding="2rem">
       {isFetched &&
         data?.pages.map((page, index) => {
           return (

--- a/src/components/Challenge/Banner/ChallengeOfferInput.tsx
+++ b/src/components/Challenge/Banner/ChallengeOfferInput.tsx
@@ -27,20 +27,12 @@ const ChallengeOfferInput = () => {
   const { mutate: addSuggestion } = useAddChallengeSuggestion({ onSuccess });
 
   return (
-    <ChallengeBanner
-      title={script.title}
-      width="76rem"
-      padding="2rem"
-      maxWidthTablet="1250px"
-      widthTablet="51rem"
-      maxWidthMobile="768px"
-      widthMobile="26.5rem"
-    >
+    <ChallengeBanner title={script.title} width="100%" padding="2rem">
       <Textarea
         value={value}
         onChange={onChangeValue}
-        width="98%"
-        margin="1rem 0 0 0"
+        width="100%"
+        margin="1rem 0"
         text={script.text}
         minRow={6}
         maxLength={100}
@@ -48,7 +40,7 @@ const ChallengeOfferInput = () => {
       <FlexBox
         justifyContent="space-between"
         alignItems="center"
-        margin="0.5rem 1rem"
+        padding="1rem 0"
         background={COLOR.bg.primary}
       >
         <FlexTextBox
@@ -59,6 +51,7 @@ const ChallengeOfferInput = () => {
           글자 수 {value.length} / 100
         </FlexTextBox>
         <FlexButton
+          margin="0"
           fontSize="1.1rem"
           onClick={handleSubmit}
           fontFamily="Pr-Bold"

--- a/src/components/Challenge/Card/ChallengeOfferCard.tsx
+++ b/src/components/Challenge/Card/ChallengeOfferCard.tsx
@@ -8,20 +8,31 @@ interface Props {
   content: string;
   feedbackCount: number;
   isFeedbacked: boolean;
-  margin?: string;
+  gap?: string;
 }
 
 const defaultProps = {
-  margin: "0.5rem 1rem 0.5rem 0rem",
+  gap: "1rem",
 };
 
-const Container = styled.div<{ margin: string }>`
-  width: 22rem;
+const Container = styled.div<{ gap: string }>`
   height: auto;
   border-radius: 1rem;
   background-color: ${COLOR.bg.secondary};
   padding: 0.7rem 1.5rem 0.7rem 1.5rem;
-  margin: ${(props) => props.margin};
+
+  flex: 1 1 ${(props) => `calc((100% - ${props.gap} * 2) / 3)`};
+  max-width: ${(props) => `calc((100% - ${props.gap} * 2) / 3)`};
+
+  @media (max-width: 1000px) {
+    flex: 1 1 ${(props) => `calc((100% - ${props.gap} * 1) / 2)`};
+    max-width: ${(props) => `calc((100% - ${props.gap} * 1) / 2)`};
+  }
+
+  @media (max-width: 600px) {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
 `;
 
 const User = styled.div`
@@ -53,8 +64,13 @@ const LikeNumber = styled.span`
   margin-left: 0.5rem;
 `;
 
-const ChallengeOfferCard = (props: Props) => {
-  const { suggester, content, feedbackCount, isFeedbacked, margin } = props;
+const ChallengeOfferCard = ({
+  suggester,
+  content,
+  feedbackCount,
+  isFeedbacked,
+  gap,
+}: Props) => {
   const [clicked, setClicked] = useState(isFeedbacked);
   const [like, setLike] = useState(feedbackCount);
   const clickedLike = () => {
@@ -62,7 +78,7 @@ const ChallengeOfferCard = (props: Props) => {
     setClicked((prev) => !prev);
   };
   return (
-    <Container margin={margin}>
+    <Container gap={gap}>
       <User>{suggester}</User>
       <Content>{content}</Content>
       <LikeContainer>

--- a/src/layouts/maxWidth.layout.jsx
+++ b/src/layouts/maxWidth.layout.jsx
@@ -1,11 +1,17 @@
 import styled from "styled-components";
 
 const Container = styled.div`
-  max-width: 1200px;
+  max-width: ${(props) => props.maxWidth || "1200px"};
+  padding: ${(props) => props.padding || "0 1rem"};
+  width: 100%;
 `;
 
-const MaxWidthLayout = ({ children }) => {
-  return <Container>{children}</Container>;
+const MaxWidthLayout = ({ children, maxWidth, padding }) => {
+  return (
+    <Container maxWidth={maxWidth} padding={padding}>
+      {children}
+    </Container>
+  );
 };
 
 export default MaxWidthLayout;

--- a/src/layouts/mobile.layout.jsx
+++ b/src/layouts/mobile.layout.jsx
@@ -1,11 +1,12 @@
 import MobileNavbar from "components/Navbar/MobileNavbar";
 import MobileFooter from "components/Footer/MobileFooter";
+import MaxWidthLayout from "./maxWidth.layout";
 
 const MobileLayout = ({ children }) => {
   return (
     <>
       <MobileNavbar />
-      <div>{children}</div>
+      <MaxWidthLayout>{children}</MaxWidthLayout>
       <MobileFooter />
     </>
   );


### PR DESCRIPTION
## 작업 내용
- 챌린지 제안 페이지 레이아웃 조절
- Flex로 자연스러운 반응형 디자인이 되도록 리팩토링했습니다.

## 기타 사항
![image](https://user-images.githubusercontent.com/47373998/189176443-d9841d33-96a3-43d9-aa9f-5f728ab9c113.png)

![image](https://user-images.githubusercontent.com/47373998/189176501-bf34008c-439d-4549-823d-8e7ef2aabdc9.png)

![image](https://user-images.githubusercontent.com/47373998/189176563-8d2307fa-fc88-4775-9fb5-b450355b2a74.png)

![image](https://user-images.githubusercontent.com/47373998/189176594-4df12f4b-1db4-4ad5-a15f-e3f0728df340.png)

![image](https://user-images.githubusercontent.com/47373998/189176634-0deb7beb-c6ef-4c92-8567-cf7df460b29f.png)

![image](https://user-images.githubusercontent.com/47373998/189176672-72a3152c-6fbb-4295-9765-d63224b9894b.png)
