### PR TITLE
Bug/138 모달 스크롤 시 쏠리는 버그 해결 + 반응형

### DIFF
--- a/src/components/Form/Textarea.tsx
+++ b/src/components/Form/Textarea.tsx
@@ -6,6 +6,7 @@ import { css } from "@emotion/react";
 interface Props {
   text: string;
   width?: string;
+  mobileWidth?: string;
   minRow?: number;
   margin?: string;
   padding?: string;
@@ -18,6 +19,7 @@ interface Props {
 
 const defaultProps = {
   width: "45rem",
+  mobileWidth: "100%",
   minRow: 1,
   margin: "0",
   padding: "1.25rem",
@@ -30,6 +32,7 @@ const Textarea = (props: Props) => {
   const {
     text,
     width,
+    mobileWidth,
     minRow,
     margin,
     padding,
@@ -61,6 +64,10 @@ const Textarea = (props: Props) => {
         background-color: ${background} !important;
         margin: ${margin};
         resize: none;
+
+        @media only screen and (max-width: 767px) {
+          width: ${mobileWidth} !important;
+        }
       `}
     />
   );

--- a/src/components/Modal/ChallengeConfirmModal.tsx
+++ b/src/components/Modal/ChallengeConfirmModal.tsx
@@ -27,7 +27,7 @@ const dummyData = {
   id: "1",
   avatar: "images/man.png",
   userName: "홍길동",
-  subTitle: false,
+  subTitle: true,
 };
 
 const Avatar = styled.img`
@@ -117,7 +117,13 @@ const ChallengeConfirmModal = ({
       type={type}
       subTitle={subTitle}
     >
-      <BannerBox position="relative" theme="transparent" padding="0" margin="0">
+      <BannerBox
+        position="relative"
+        theme="transparent"
+        padding="0"
+        margin="0"
+        widthMobile="15rem"
+      >
         <FlexBox
           background={COLOR.bg.nav}
           borderRadius="1.25rem"
@@ -140,6 +146,7 @@ const ChallengeConfirmModal = ({
             onChange={onChangeContent}
             text="챌린지 인증 글을 입력해주세요"
             width="43rem"
+            mobileWidth="13rem"
             minRow={2}
           />
         </FlexBox>
@@ -180,60 +187,83 @@ const ChallengeConfirmModal = ({
           </FlexBox>
         </FlexBox>
 
-        <FlexBox
-          background="transparent"
-          margin="2rem 2.5rem 1.5rem 2.5rem"
-          height="2rem"
-        >
-          {subTitle && (
+        <FlexBox column padding="0 2rem" mobilePadding="0.1rem">
+          <FlexBox
+            background="transparent"
+            width="100%"
+            mobileWidth="100%"
+            margin="2rem 0 0.5rem 0"
+            height="2rem"
+          >
+            {subTitle && (
+              <FlexBox
+                justifyContent="space-between"
+                alignItems="center"
+                width="100%"
+                mobileWidth="100%"
+              >
+                <FlexTextBox
+                  fontSize="1.5rem"
+                  mobileFontSize="0.8rem"
+                  margin="0.1rem 0 0 0"
+                  width="100%"
+                >
+                  이 글을 피스에도 같이 올릴까요?
+                </FlexTextBox>
+                <Toggle checked={false} />
+              </FlexBox>
+            )}
+          </FlexBox>
+          <FlexBox
+            background="transparent"
+            margin="1.4rem 0"
+            height="2rem"
+            width="100%"
+            mobileWidth="100%"
+          >
             <FlexBox
               justifyContent="space-between"
               alignItems="center"
               width="100%"
+              mobileWidth="100%"
             >
-              <FlexTextBox fontSize="1.5rem" margin="0.1rem 0 0 0">
-                이 글을 피스에도 같이 올릴까요?
+              <FlexTextBox
+                fontSize="1.5rem"
+                mobileFontSize="0.8rem"
+                margin="0.1rem 0 0 0"
+                width="100%"
+              >
+                페이스북 공유
               </FlexTextBox>
-              <FlexBox>
-                <Toggle checked={false} />
-              </FlexBox>
-            </FlexBox>
-          )}
-        </FlexBox>
-        <FlexBox background="transparent" margin="1.4rem 2.5rem" height="2rem">
-          <FlexBox
-            justifyContent="space-between"
-            alignItems="center"
-            width="100%"
-          >
-            <FlexTextBox fontSize="1.5rem" margin="0.1rem 0 0 0">
-              페이스북 공유
-            </FlexTextBox>
-            <FlexBox>
               <Toggle checked={false} />
             </FlexBox>
           </FlexBox>
-        </FlexBox>
-        <FlexBox
-          background="transparent"
-          margin="0.5rem 2.5rem 4rem 2.5rem"
-          height="2rem"
-        >
           <FlexBox
-            justifyContent="space-between"
-            alignItems="center"
+            background="transparent"
+            margin="0.5rem 0 4rem 0"
+            height="2rem"
             width="100%"
+            mobileWidth="100%"
           >
-            <FlexBox>
-              <FlexTextBox fontSize="1.5rem" margin="0.1rem 0 0 0">
-                인스타그램 공유
-              </FlexTextBox>
-              <Tooltip
-                text="인스타그램 공유는 계정 연동 후 사용할 수 있어요 🥺"
-                margin="0 0 0 0.5rem"
-              />
-            </FlexBox>
-            <FlexBox>
+            <FlexBox
+              justifyContent="space-between"
+              alignItems="center"
+              width="100%"
+              mobileWidth="100%"
+            >
+              <FlexBox width="100%">
+                <FlexTextBox
+                  fontSize="1.5rem"
+                  margin="0.1rem 0 0 0"
+                  mobileFontSize="0.8rem"
+                >
+                  인스타그램 공유
+                </FlexTextBox>
+                <Tooltip
+                  text="인스타그램 공유는 계정 연동 후 사용할 수 있어요 🥺"
+                  margin="0"
+                />
+              </FlexBox>
               <Toggle checked={false} />
             </FlexBox>
           </FlexBox>

--- a/src/components/Modal/ModalFrame.tsx
+++ b/src/components/Modal/ModalFrame.tsx
@@ -93,9 +93,10 @@ const ModalFrame = (props: AreaElement) => {
           <FlexBox
             background={background}
             width={width}
+            mobileWidth="20rem"
             height={height}
             column
-            padding="3rem"
+            padding="2.5rem"
             borderRadius="1.25rem"
             margin="auto"
           >
@@ -109,6 +110,7 @@ const ModalFrame = (props: AreaElement) => {
                 <FlexTextBox
                   color={modalMainColor}
                   fontSize="1.875rem"
+                  mobileFontSize="1.2rem"
                   fontFamily="Pr-Bold"
                 >
                   {title}
@@ -117,8 +119,10 @@ const ModalFrame = (props: AreaElement) => {
                   <FlexTextBox
                     color={COLOR.white}
                     fontSize="1.875rem"
+                    mobileFontSize="1rem"
                     fontFamily="Pr-Bold"
                     margin="0 0 0 1rem"
+                    mobileDisplay="none"
                   >
                     챌린지 인증하기
                   </FlexTextBox>
@@ -134,6 +138,7 @@ const ModalFrame = (props: AreaElement) => {
             <FlexBox
               position="relative"
               left={type === "warning" ? "23rem" : "27rem"}
+              mobileLeft={type === "warning" ? "0" : "0rem"}
               top={type === "warning" ? "7rem" : "1rem"}
             >
               <FlexButton

--- a/src/components/Modal/ModalFrame.tsx
+++ b/src/components/Modal/ModalFrame.tsx
@@ -97,10 +97,7 @@ const ModalFrame = (props: AreaElement) => {
             column
             padding="3rem"
             borderRadius="1.25rem"
-            position="relative"
-            top="50%"
-            left="25%"
-            transform="translateY(-50%)"
+            margin="auto"
           >
             <FlexBox
               width="100%"

--- a/src/components/common/BannerBox.tsx
+++ b/src/components/common/BannerBox.tsx
@@ -83,7 +83,7 @@ const BannerBox = (props: Props) => {
         @media only screen and (max-width: ${maxWidthTablet}) {
           width: ${widthTablet};
         }
-        @media only screen and (max-width: ${maxWidthMobile}) {
+        @media only screen and (max-width: 767px) {
           width: ${widthMobile};
         }
       `}

--- a/src/components/common/FlexBox.tsx
+++ b/src/components/common/FlexBox.tsx
@@ -8,6 +8,7 @@ interface Props {
   height?: string;
   margin?: string;
   padding?: string;
+  mobilePadding?: string;
   shadow?: boolean;
   borderRadius?: string;
   column?: boolean;
@@ -20,19 +21,23 @@ interface Props {
   position?: string;
   top?: string;
   left?: string;
+  mobileLeft?: string;
   right?: string;
   bottom?: string;
   gap?: string;
   float?: string;
   transform?: string;
+  mobileWidth?: string;
 }
 
 const defaultProps = {
   width: "auto",
   maxWidth: "none",
+  mobileWidth: "100%",
   height: "auto",
   margin: "0",
   padding: "0",
+  mobilePadding: "0",
   shadow: false,
   borderRadius: "",
   column: false,
@@ -45,6 +50,7 @@ const defaultProps = {
   background: "transparent",
   top: "0",
   left: "0",
+  mobileLeft: "0",
   right: "0",
   bottom: "0",
   gap: "0",
@@ -56,10 +62,12 @@ const FlexBox = (props: Props) => {
   const {
     children,
     width,
+    mobileWidth,
     maxWidth,
     height,
     margin,
     padding,
+    mobilePadding,
     shadow,
     borderRadius,
     column,
@@ -72,6 +80,7 @@ const FlexBox = (props: Props) => {
     position,
     top,
     left,
+    mobileLeft,
     right,
     bottom,
     gap,
@@ -105,6 +114,12 @@ const FlexBox = (props: Props) => {
         gap: ${gap};
         float: ${float};
         transform: ${transform};
+
+        @media only screen and (max-width: 767px) {
+          width: ${mobileWidth};
+          left: ${mobileLeft};
+          padding: ${mobilePadding !== "0" ? mobilePadding : padding};
+        }
       `}
     >
       {children}

--- a/src/components/common/FlexTextBox.tsx
+++ b/src/components/common/FlexTextBox.tsx
@@ -13,6 +13,8 @@ interface Props {
   right?: string;
   bottom?: string;
   background?: string;
+  mobileFontSize?: string;
+  mobileDisplay?: string;
 }
 
 const defaultProps = {
@@ -26,12 +28,15 @@ const defaultProps = {
   right: "0",
   bottom: "0",
   background: "transparent",
+  mobileFontSize: "1rem",
+  mobileDisplay: "block",
 };
 
 const FlexTextBox = (props: Props) => {
   const {
     children,
     width,
+    mobileFontSize,
     height,
     margin,
     fontSize,
@@ -41,6 +46,7 @@ const FlexTextBox = (props: Props) => {
     right,
     bottom,
     background,
+    mobileDisplay,
   } = props;
 
   return (
@@ -58,6 +64,11 @@ const FlexTextBox = (props: Props) => {
         right: ${right};
         bottom: ${bottom};
         background: ${background};
+
+        @media only screen and (max-width: 767px) {
+          font-size: ${mobileFontSize};
+          display: ${mobileDisplay};
+        }
       `}
     >
       {children}

--- a/src/components/common/Toggle.tsx
+++ b/src/components/common/Toggle.tsx
@@ -36,6 +36,15 @@ const Circle = styled.div<Props>`
       transform: translate(1.7rem, 0);
       transition: all 0.5s ease-in-out;
     `}
+
+  @media only screen and (max-width: 767px) {
+    ${(props) =>
+      props.checked &&
+      css`
+        transform: translate(1.3rem, 0);
+        transition: all 0.5s ease-in-out;
+      `}
+  }
 `;
 
 const Toggle = (props: Props) => {


### PR DESCRIPTION
## 작업 내용
- 스크롤 시 모달이 쏠리는 버그를 해결했습니다
- 하면서 반응형 모달도 함께 작업했습니다

![스크린샷 2022-09-09 오후 5 39 40](https://user-images.githubusercontent.com/66055587/189309155-9b78ee7d-e783-4c76-8a5c-9d7da631e08f.png)

- @soyekwon 이전에 챌린지 제안에서 반응형 사용하는 컴포넌트들에 max-width 다 넣어줬던데, 어차피 해당 px이 되면 media 안에 있는 코드가 작동하는거라 인자로 안넘기고 이렇게 고정시켜놓는게 맞는거 같아서 이 부분 수정했어!

<img width="327" alt="스크린샷 2022-09-09 오후 5 31 00" src="https://user-images.githubusercontent.com/66055587/189307720-3e974e1f-29e7-49e8-b9c4-bfdda21f3f18.png">

