### PR TITLE
Bug/196 챌린지 제안카드, 위클리 챌린지 깨짐현상 해결 + 메인 화면 챌린지 제안 목록 반응형 디자인

### DIFF
--- a/src/components/Challenge/AllChallengeSuggestionPartialList.tsx
+++ b/src/components/Challenge/AllChallengeSuggestionPartialList.tsx
@@ -1,5 +1,6 @@
 import { ChallengeSuggestionType } from "types";
 import ChallengeSuggestionCard from "./Card/ChallengeSuggestionCard";
+import ChallengeSuggestionGatherWrapper from "./Card/ChallengeSuggestionGatherWrapper";
 
 interface Props {
   suggestions: ChallengeSuggestionType[];
@@ -11,11 +12,13 @@ const AllChallengeSuggestionPartialList = (props: Props) => {
     <>
       {suggestions.map((suggestion) => {
         return (
-          <ChallengeSuggestionCard
+          <ChallengeSuggestionGatherWrapper
             key={`suggestion-${suggestion.id}`}
-            suggestion={suggestion}
             gap="1rem"
-          />
+            all
+          >
+            <ChallengeSuggestionCard suggestion={suggestion} />
+          </ChallengeSuggestionGatherWrapper>
         );
       })}
     </>

--- a/src/components/Challenge/Banner/ChallengeSuggestionGather.tsx
+++ b/src/components/Challenge/Banner/ChallengeSuggestionGather.tsx
@@ -4,6 +4,7 @@ import COLOR from "constants/color";
 import { FlexBox } from "components/common";
 import { useChallengeSuggestionListData } from "hooks/queries/challenge/suggestion";
 import { ChallengeSuggestionType } from "types";
+import ChallengeSuggestionGatherWrapper from "../Card/ChallengeSuggestionGatherWrapper";
 
 const ChallengeSuggestionGather = () => {
   const { data, isFetched } = useChallengeSuggestionListData(3, "main");
@@ -25,11 +26,12 @@ const ChallengeSuggestionGather = () => {
         {isFetched &&
           data.pages[0].data.results.map(
             (suggestion: ChallengeSuggestionType) => (
-              <ChallengeSuggestionCard
+              <ChallengeSuggestionGatherWrapper
                 key={`challenge_suggestion_${suggestion.id}`}
-                suggestion={suggestion}
                 gap="1rem"
-              />
+              >
+                <ChallengeSuggestionCard suggestion={suggestion} />
+              </ChallengeSuggestionGatherWrapper>
             )
           )}
       </FlexBox>

--- a/src/components/Challenge/Card/ChallengeCard.tsx
+++ b/src/components/Challenge/Card/ChallengeCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, Navigate, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import COLOR from "constants/color";
 import { ChallengeFigure, DidItIcon } from "components/Challenge";
@@ -86,33 +86,35 @@ const HashTag = styled.div`
 
 const ChallengeCard = (props: Props) => {
   const { challenge, margin } = props;
+  const navigate = useNavigate();
+  const onClickCard = () => {
+    navigate(`/challenge/${challenge.id}`);
+  };
   return (
-    <Link to={`/challenge/${challenge.id}`}>
-      <Container margin={margin} key={challenge.id}>
-        <Thumbnail
-          src={challenge.thumbnail.file}
-          isProved={challenge.is_proved}
+    <Container margin={margin} key={challenge.id} onClick={onClickCard}>
+      <Thumbnail
+        src={challenge.thumbnail.file}
+        isProved={challenge.is_proved}
+      />
+      {challenge.is_proved && (
+        <DidItIcon isAbsolute top="1rem" right="1rem" mobileLeft="1.5rem" />
+      )}
+      <ContentBox>
+        <Title>{challenge.title}</Title>
+        <ChallengeFigure
+          proverCnt={challenge.prover_cnt}
+          point={challenge.point}
+          background={COLOR.bg.secondary}
         />
-        {challenge.is_proved && (
-          <DidItIcon isAbsolute top="1rem" right="1rem" mobileLeft="1.5rem" />
-        )}
-        <ContentBox>
-          <Title>{challenge.title}</Title>
-          <ChallengeFigure
-            proverCnt={challenge.prover_cnt}
-            point={challenge.point}
-            background={COLOR.bg.secondary}
-          />
-          <HashTagBox>
-            {challenge.categories.map((category) => (
-              <HashTag key={`challenge-category-${category.id}`}>
-                #{category.title}
-              </HashTag>
-            ))}
-          </HashTagBox>
-        </ContentBox>
-      </Container>
-    </Link>
+        <HashTagBox>
+          {challenge.categories.map((category) => (
+            <HashTag key={`challenge-category-${category.id}`}>
+              #{category.title}
+            </HashTag>
+          ))}
+        </HashTagBox>
+      </ContentBox>
+    </Container>
   );
 };
 ChallengeCard.defaultProps = defaultProps;

--- a/src/components/Challenge/Card/ChallengeCard.tsx
+++ b/src/components/Challenge/Card/ChallengeCard.tsx
@@ -1,4 +1,4 @@
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import COLOR from "constants/color";
 import { ChallengeFigure, DidItIcon } from "components/Challenge";

--- a/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
+++ b/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
@@ -41,11 +41,16 @@ const User = styled.div`
 `;
 
 const Content = styled.div`
-  height: 5rem;
+  height: 5.5rem;
   font-size: 1rem;
   font-family: "Pr-SemiBold";
   color: ${COLOR.white};
   margin-bottom: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
 `;
 
 const LikeContainer = styled.div`

--- a/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
+++ b/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
@@ -42,9 +42,8 @@ const Content = styled.div`
 `;
 
 const LikeContainer = styled.div`
-  float: right;
   display: flex;
-  justify-content: center;
+  justify-content: end;
   align-items: center;
 `;
 

--- a/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
+++ b/src/components/Challenge/Card/ChallengeSuggestionCard.tsx
@@ -19,18 +19,6 @@ const Container = styled.div<{ gap: string }>`
   background-color: ${COLOR.bg.secondary};
   padding: 0.7rem 1.5rem 0.7rem 1.5rem;
   margin: 0 0 1rem 0;
-
-  flex: 1 1 ${(props) => `calc((100% - ${props.gap} * 2) / 3)`};
-  max-width: ${(props) => `calc((100% - ${props.gap} * 2) / 3)`};
-
-  @media (max-width: 1023px) {
-    flex: 1 1 ${(props) => `calc((100% - ${props.gap} * 1) / 2)`};
-    max-width: ${(props) => `calc((100% - ${props.gap} * 1) / 2)`};
-  }
-  @media (max-width: 767px) {
-    flex: 1 1 100%;
-    max-width: 100%;
-  }
 `;
 
 const User = styled.div`

--- a/src/components/Challenge/Card/ChallengeSuggestionGatherWrapper.tsx
+++ b/src/components/Challenge/Card/ChallengeSuggestionGatherWrapper.tsx
@@ -13,6 +13,8 @@ const defaultProps = {
 };
 
 const Wrapper = styled.div<{ gap: string; all: boolean }>`
+  height: auto;
+
   ${(props) =>
     props.all
       ? css`

--- a/src/components/Challenge/Card/ChallengeSuggestionGatherWrapper.tsx
+++ b/src/components/Challenge/Card/ChallengeSuggestionGatherWrapper.tsx
@@ -1,0 +1,60 @@
+import { ReactNode } from "react";
+import styled, { css } from "styled-components";
+
+interface WrapperProps {
+  children: ReactNode;
+  gap?: string;
+  all?: boolean;
+}
+
+const defaultProps = {
+  gap: "0rem",
+  all: false,
+};
+
+const Wrapper = styled.div<{ gap: string; all: boolean }>`
+  ${(props) =>
+    props.all
+      ? css`
+          flex: 1 1 ${`calc((100% - ${props.gap} * 2) / 3)`};
+          max-width: ${`calc((100% - ${props.gap} * 2) / 3)`};
+
+          @media (max-width: 1023px) {
+            flex: 1 1 ${`calc((100% - ${props.gap} * 1) / 2)`};
+            max-width: ${`calc((100% - ${props.gap} * 1) / 2)`};
+          }
+          @media (max-width: 767px) {
+            flex: 1 1 100%;
+            max-width: 100%;
+          }
+        `
+      : css`
+          flex: 1 1 ${`calc((100% - ${props.gap} * 2) / 2)`};
+          max-width: ${`calc((100% - ${props.gap} * 2) / 2)`};
+
+          @media (max-width: 1023px) {
+            flex: 1 1 ${`calc((100% - ${props.gap} * 1) / 2)`};
+            max-width: ${`calc((100% - ${props.gap} * 1) / 2)`};
+          }
+          @media (max-width: 767px) {
+            flex: 1 1 100%;
+            max-width: 100%;
+          }
+        `}
+`;
+
+const ChallengeSuggestionGatherWrapper = ({
+  children,
+  gap,
+  all,
+}: WrapperProps) => {
+  return (
+    <Wrapper gap={gap} all={all}>
+      {children}
+    </Wrapper>
+  );
+};
+
+ChallengeSuggestionGatherWrapper.defaultProps = defaultProps;
+
+export default ChallengeSuggestionGatherWrapper;

--- a/src/components/Challenge/Card/WeeklyChallengeCard.tsx
+++ b/src/components/Challenge/Card/WeeklyChallengeCard.tsx
@@ -27,7 +27,9 @@ const WeeklyChallengeCard = ({ challenge }: Props) => {
     <Link to={`/challenge/${challenge.id}`}>
       <FlexBox
         column
-        width="21.3rem"
+        width="18rem"
+        tabletWidth="21.5rem"
+        mobileWidth="21.5rem"
         height="9.25rem"
         borderRadius="1.25rem"
         background={COLOR.bg.secondary}

--- a/src/components/Challenge/Card/WeeklyChallengeCard.tsx
+++ b/src/components/Challenge/Card/WeeklyChallengeCard.tsx
@@ -2,11 +2,25 @@ import { Link } from "react-router-dom";
 import { FlexBox, FlexTextBox } from "components/common";
 import COLOR from "constants/color";
 import { ChallengeType } from "types";
+import styled from "styled-components";
 import ChallengeFigure from "../ChallengeFigure";
 
 interface Props {
   challenge: ChallengeType;
 }
+
+const Description = styled.div`
+  width: 100%;
+  margin: 0.5rem 0 0 0;
+  height: 3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: ${COLOR.white};
+  font-family: "Pr-SemiBold";
+`;
 
 const WeeklyChallengeCard = ({ challenge }: Props) => {
   return (
@@ -31,7 +45,7 @@ const WeeklyChallengeCard = ({ challenge }: Props) => {
           proverCnt={challenge.prover_cnt}
           point={challenge.point}
         />
-        <FlexTextBox margin="0.5rem 0 0 0">{challenge.description}</FlexTextBox>
+        <Description>{challenge.description}</Description>
       </FlexBox>
     </Link>
   );

--- a/src/components/Challenge/WeeklyChallengeList.tsx
+++ b/src/components/Challenge/WeeklyChallengeList.tsx
@@ -53,12 +53,15 @@ const arrLoop = (challenges: ChallengeType[]) => {
     newArr.push(
       <Page key={`weekly_challenge_page_${i}`}>
         {i === challenges.length - 1 && challenges.length % 2 === 1 ? (
-          <FlexBox margin="1rem 0.5rem 0 1rem" background={COLOR.bg.primary}>
+          <FlexBox margin="1rem 0.5rem 0 3rem" background={COLOR.bg.primary}>
             <WeeklyChallengeCard challenge={challenges[i]} />
           </FlexBox>
         ) : (
           <>
-            <FlexBox margin="1rem 0.5rem 0 3rem" background={COLOR.bg.primary}>
+            <FlexBox
+              margin="1rem 0.5rem 0 3.5rem"
+              background={COLOR.bg.primary}
+            >
               <WeeklyChallengeCard challenge={challenges[i]} />
             </FlexBox>
             <FlexBox margin="1rem 1rem 0 0.5rem" background={COLOR.bg.primary}>

--- a/src/components/Challenge/WeeklyChallengeList.tsx
+++ b/src/components/Challenge/WeeklyChallengeList.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 `;
 
 const CarouselLib = styled(Carousel)`
-  width: 50.5rem;
+  width: 100%;
   height: 10.5rem;
   margin: auto;
   background-color: ${COLOR.bg.primary};
@@ -34,7 +34,7 @@ const CarouselLib = styled(Carousel)`
 `;
 
 const Page = styled(Paper)`
-  width: 49rem;
+  width: 100%;
   margin-left: 0.5rem;
   display: flex;
   border: none !important;

--- a/src/components/common/FlexBox.tsx
+++ b/src/components/common/FlexBox.tsx
@@ -5,6 +5,7 @@ interface Props {
   children: React.ReactNode;
   width?: string;
   maxWidth?: string;
+  tabletWidth?: string;
   height?: string;
   margin?: string;
   tabletMargin?: string;
@@ -34,6 +35,7 @@ interface Props {
 const defaultProps = {
   width: "auto",
   maxWidth: "none",
+  tabletWidth: "",
   mobileWidth: "",
   height: "auto",
   margin: "0",
@@ -64,6 +66,7 @@ const FlexBox = (props: Props) => {
   const {
     children,
     width,
+    tabletWidth,
     mobileWidth,
     maxWidth,
     height,
@@ -119,6 +122,7 @@ const FlexBox = (props: Props) => {
         transform: ${transform};
 
         @media only screen and (min-width: 768px) and (max-width: 1023px) {
+          width: ${tabletWidth};
           margin: ${tabletMargin !== "0" ? tabletMargin : margin};
         }
 


### PR DESCRIPTION
## 작업 내용
- 제목에 적은 내용들 작업했습니다.

<img width="739" alt="스크린샷 2022-09-11 오후 11 09 14" src="https://user-images.githubusercontent.com/66055587/189532040-ee7e119b-2125-42af-a656-011c954e5f3b.png">
<img width="1158" alt="스크린샷 2022-09-11 오후 11 09 19" src="https://user-images.githubusercontent.com/66055587/189532044-bfd9feea-f7a6-41e2-90cf-e7e1be7b1040.png">
<img width="746" alt="스크린샷 2022-09-11 오후 11 09 25" src="https://user-images.githubusercontent.com/66055587/189532047-cfa55f4d-9757-47f0-8f6b-2be7b0cceb5a.png">

- 그리고 이거 위클리 챌린지 화면 줄이면 이렇게 오른쪽이 살짝 씹히는데, @soyekwon 이거 한 번 확인 부탁함당

<img width="655" alt="스크린샷 2022-09-11 오후 11 09 53" src="https://user-images.githubusercontent.com/66055587/189532416-a2c11c33-c0ce-43a8-9864-8ab3ea8cced6.png">
