### PR TITLE
fix: 링크 추가

### DIFF
--- a/src/components/Footer/DesktopFooter.tsx
+++ b/src/components/Footer/DesktopFooter.tsx
@@ -7,7 +7,7 @@ const Foot = styled.div`
   width: 100%;
   height: 5rem;
   position: relative;
-  transform: translateY(100%);
+  transform: translateY(50%);
   background: ${COLOR.bg.default};
 `;
 
@@ -89,7 +89,9 @@ const Footer = () => {
         <Line />
       </FlexBox>
       <FlexBox padding="0.8rem 9rem">
-        <Label style={{ width: "12rem" }}>Team TTL | PeacePice</Label>
+        <a href="https://github.com/today-they-learned">
+          <Label style={{ width: "12rem" }}>Team TTL | PeacePice</Label>
+        </a>
       </FlexBox>
     </Foot>
   );

--- a/src/components/Footer/MobileFooter.tsx
+++ b/src/components/Footer/MobileFooter.tsx
@@ -82,7 +82,9 @@ const MobileFooter = () => {
         <Line />
       </FlexBox>
       <FlexBox padding="0.8rem 1rem">
-        <Label style={{ width: "12rem" }}>Team TTL | PeacePice</Label>
+        <a href="https://github.com/today-they-learned">
+          <Label style={{ width: "12rem" }}>Team TTL | PeacePice</Label>
+        </a>
       </FlexBox>
     </Foot>
   );


### PR DESCRIPTION
풋바 하단에 고졍하려고 position: fixed, relative, absolute, transform: translateY(100%), flex 속성 다 써봤는데 


![스크린샷(89)](https://user-images.githubusercontent.com/55877726/190181658-1eaf43cb-8b62-444f-8cf0-8d899f304888.png)
콘텐츠 높이 영역이 짧은 페이지엔 위 사진처럼 잘 고정이 되지만 



![스크린샷(91)](https://user-images.githubusercontent.com/55877726/190181801-dfd37c0e-535c-4204-913e-91e9ad3d26f6.png)
무한 스크롤이 있거나 컴포넌트가 한 페이지를 넘어가는 페이지엔 위 사진처럼 둥둥 뜨게됩니다.

그래서 나중에 데이터 다 넣고 나면 콘텐츠 높이가 짧은 페이지 몇 안될거 같아서 

그 페이지에만 margin-bottom을 주거나 또는 

 position: fixed로 하단에 고정해야할듯 ! 그런데 이 경우는 무한스크롤에서 스크롤을 내리고 있는 와중에도 풋바가 아래에 고정되어있어요 
둘 중에 어떤 방법이 좋을까요 ? 